### PR TITLE
Problem: New problem don't have a default status tag #74

### DIFF
--- a/imports/api/documents/both/problemMethods.js
+++ b/imports/api/documents/both/problemMethods.js
@@ -38,7 +38,8 @@ export const addProblem = new ValidatedMethod({
 		return Problems.insert({
 			'summary': summary,
 			'description': description || "",
-			'solution': solution || "",
+            'solution': solution || "",
+            'status': 'open', // we assign a default status of open
 			'createdAt': new Date().getTime(),
 			'createdBy': Meteor.userId() || ""
 		})

--- a/imports/api/documents/both/problemMethods.test.js
+++ b/imports/api/documents/both/problemMethods.test.js
@@ -24,6 +24,22 @@ describe('problem methods', () => {
         })
     })
 
+    it('can add new problem with a default status of open', () => {
+        let data = {}
+
+        data.summary = 'Test summary'
+        data.description = 'an awesome test description...'
+        data.solution = 'a very valid test solution for problem...'
+
+        return callWithPromise('addProblem', data)
+            .then(problemId => {
+                let problem = Problems.findOne({ _id : problemId})
+
+                assert(Problems.find({}).count() === 2)
+                assert(problem.status === 'open')
+            })
+    })
+
     it('can mark problem as resolved if current user is claimer', () => {
         let problem = Problems.findOne({})
         assert.ok(problem)


### PR DESCRIPTION
Solution: Adding status property with value of open when adding a new problem. Testing that user can add problem with a default status.