### PR TITLE
Problem: No user statistics (#91)

### DIFF
--- a/imports/api/stats/both/statsCollection.js
+++ b/imports/api/stats/both/statsCollection.js
@@ -1,0 +1,7 @@
+export const Stats = new Mongo.Collection('stats')
+
+if (Meteor.isServer) {
+	Meteor.publish('userStats', uId => Stats.find({
+		userId: uId || Meteor.userId() // default to the current user if available
+	}))
+}

--- a/imports/api/user/server/publications.js
+++ b/imports/api/user/server/publications.js
@@ -1,0 +1,15 @@
+Meteor.publish('users', () => Meteor.users.find({}, {
+	fields: {
+		'profile.name': 1,
+		_id: 1
+	}
+}))
+
+Meteor.publish('user', userId => Meteor.users.find({
+	_id: userId
+}, {
+	fields: {
+		'profile.name': 1,
+		_id: 1
+	}
+}))

--- a/imports/startup/client/router/router.js
+++ b/imports/startup/client/router/router.js
@@ -8,4 +8,5 @@ import "./filter-config.js"
 
 // Routes
 import "./auth-routes.js"
+import './stats-routes.js'
 import "./document-routes.js"

--- a/imports/startup/client/router/stats-routes.js
+++ b/imports/startup/client/router/stats-routes.js
@@ -1,0 +1,14 @@
+import { FlowRouter } from 'meteor/kadira:flow-router'
+import { BlazeLayout } from 'meteor/kadira:blaze-layout'
+
+import '/imports/ui/components/stats/userStats'
+
+FlowRouter.route('/stats/:userId?', {
+    action: () => {
+        BlazeLayout.render('layout', {
+          main: 'userStats',
+          footer: 'footer'
+        })
+    },
+    name: 'stats'
+})

--- a/imports/startup/server/register-api.js
+++ b/imports/startup/server/register-api.js
@@ -5,3 +5,4 @@
 // ***************************************************************
 
 import "/imports/api/user/server/accounts-config.js"
+import '/imports/api/user/server/publications'

--- a/imports/ui/components/documents/show/document-show.js
+++ b/imports/ui/components/documents/show/document-show.js
@@ -18,6 +18,7 @@ Template.documentShow.onCreated(function() {
   this.autorun(() => {
     this.subscribe("problems", this.getDocumentId())
     this.subscribe("comments", this.getDocumentId())
+    this.subscribe('users')
   })
 })
 
@@ -61,11 +62,20 @@ Template.documentShow.events({
     "click .toggleProblem" (event) {
         var status = event.target.id === 'closeProblem' ? 'closed' :  'open';
         let problem = Problems.findOne({ _id : Template.instance().getDocumentId() })
+        let claimer = Meteor.users.findOne({
+            _id: problem.claimedBy
+        })
+        let info = ''
 
          if (Meteor.userId()) {
+            if (status === 'closed' && claimer && confirm(`Was this problem actually solved by ${(claimer.profile || {}).name}?`)) { // lazy eval ftw
+                info = 'actually-solved'
+            }
+
              updateStatus.call({
                  problemId: problem._id,
-                 status: status
+                 status: status,
+                 info: info
              }, (error, response) => {
                  if (error) { console.log(error) }
              })

--- a/imports/ui/components/stats/userStats.html
+++ b/imports/ui/components/stats/userStats.html
@@ -1,0 +1,35 @@
+<template name="userStats">
+  <div class="stats-index">
+    <div class="card">
+      <div class="card-body">
+        <h1>{{username}}'s stats</h1>
+
+        {{#if Template.subscriptionsReady}}
+            <table class="table table-hover mt-3">
+              <thead>
+                <tr>
+                  <th>Logged problems</th>
+                  <th>Claimed problems</th>
+                  <th>Abandoned problems</th>
+                  <th>Completed problems</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{#with stats}}
+                <tr class="stats-item">
+                  <td scope="row">{{nullify loggedProblems.length}}</td>
+                  <td>{{nullify claimedProblems.length}}</td>
+                  <td>{{nullify unclaimedProblems.length}} ({{fixed unclaimedPercentage}}%)</td>
+                  <td>{{nullify completedProblems.length}} ({{fixed completedPercentage}}%)</td>
+                </tr>
+                {{/with}}
+              </tbody>
+            </table>
+        {{else}}
+          {{> loader}}
+        {{/if}}
+      </div>
+    </div>
+  </div>
+
+</template>

--- a/imports/ui/components/stats/userStats.js
+++ b/imports/ui/components/stats/userStats.js
@@ -1,0 +1,33 @@
+import { Template } from 'meteor/templating'
+import { FlowRouter } from 'meteor/kadira:flow-router'
+
+import { Stats } from '/imports/api/stats/both/statsCollection.js'
+
+import './userStats.html'
+
+Template.userStats.onCreated(function() {
+    this.autorun(() => {
+        let userId = FlowRouter.getParam('userId') || Meteor.userId()
+
+        this.subscribe('userStats', userId)
+        this.subscribe('user', userId)
+    })
+})
+
+Template.userStats.helpers({
+    stats: () => Stats.findOne({
+        userId: FlowRouter.getParam('userId') || Meteor.userId()
+    }) || {},
+    username: () => ((Meteor.users.findOne({
+        _id: FlowRouter.getParam('userId') || Meteor.userId()
+    }) || {}).profile || {}).name,
+    unclaimedPercentage: function() {
+        return ((this.claimedProblems || []).length > 0 ? ((this.unclaimedProblems || []).length / this.claimedProblems.length) : 0) * 100
+    },
+    completedPercentage: function() {
+        return ((this.claimedProblems || []).length > 0 ? ((this.completedProblems || []).length / this.claimedProblems.length) : 0) * 100
+    },
+    fixed: val => parseInt(val) !== val ? val.toFixed(2) : val, // fix decimal points only if there are some to prevent 100.00,
+    nullify: val => val || 0
+})
+


### PR DESCRIPTION
Solution: Track user statistics, count the number of logged, claimed, unclaimed and completed problems. Show user's stats (numbers and percentages) at `/stats` route (for the current user) or `/stats/userId` (for other users).