### PR TITLE
Problem: Maintainers cannot delete other users problems (#117)

### DIFF
--- a/imports/api/documents/both/problemMethods.js
+++ b/imports/api/documents/both/problemMethods.js
@@ -6,6 +6,7 @@ import { Problems } from "./problemCollection.js"
 import { Stats } from '../../stats/both/statsCollection'
 
 import { sendNotification } from '/imports/api/notifications/both/notificationsMethods'
+import { isModerator } from '/imports/api/user/both/userMethods'
 
 
 //we need to move this to a global file and manage once
@@ -271,7 +272,7 @@ export const deleteProblem = new ValidatedMethod({
   			   throw new Meteor.Error('Error.', 'You have to be logged in.')
   		}
 
-      if (problem.createdBy === Meteor.userId()) {
+      if (problem.createdBy === Meteor.userId() || isModerator(Meteor.userId())) {
           Problems.remove({'_id' : id})
       } else {
           throw new Meteor.Error('Error.', 'You cannot delete the problems you did not create')

--- a/imports/api/user/both/userMethods.js
+++ b/imports/api/user/both/userMethods.js
@@ -1,0 +1,7 @@
+export const isModerator = userId => {
+	let user = Meteor.users.findOne({
+        _id: userId
+    })
+
+    return user && user.moderator
+}

--- a/imports/api/user/server/publications.js
+++ b/imports/api/user/server/publications.js
@@ -10,6 +10,17 @@ Meteor.publish('user', userId => Meteor.users.find({
 }, {
 	fields: {
 		'profile.name': 1,
-		_id: 1
+		_id: 1,
+		moderator: 1
+	}
+}))
+
+Meteor.publish(null, () => Meteor.users.find({
+	_id: Meteor.userId()
+}, {
+	fields: {
+		'profile.name': 1,
+		_id: 1,
+		moderator: 1
 	}
 }))

--- a/imports/ui/components/documents/shared/problem-helpers.js
+++ b/imports/ui/components/documents/shared/problem-helpers.js
@@ -5,7 +5,7 @@ import marked from 'marked';
 
 // check if current user created the problem
 Template.registerHelper("isProblemOwner", problemOwnerId => {
-    if (problemOwnerId !== undefined && problemOwnerId === Meteor.userId()) { return true }
+    return problemOwnerId !== undefined && problemOwnerId === Meteor.userId()
 })
 
 // check if current user has claimed problem

--- a/imports/ui/components/documents/show/document-show.html
+++ b/imports/ui/components/documents/show/document-show.html
@@ -16,6 +16,10 @@
             <a class="btn btn-sm btn-secondary" href="{{pathFor 'documentEdit' documentId=problem._id}}" role="button">Edit</a>
         		<a class="btn btn-sm btn-danger js-delete-document" href="#" role="button">Delete</a>
             {{{statusButton problem}}}
+            {{else}}
+            {{#if isModerator}}
+            <a class="btn btn-sm btn-danger js-delete-document" href="#" role="button">Delete</a>
+            {{/if}}
             {{/if}}
           </div>
 

--- a/imports/ui/helpers/handlebars-helpers.js
+++ b/imports/ui/helpers/handlebars-helpers.js
@@ -6,6 +6,8 @@ import { Template } from "meteor/templating"
 
 import * as helpers from "/imports/modules/helpers.js"
 
+import { isModerator } from '/imports/api/user/both/userMethods'
+
 // Cheap pluralization
 Template.registerHelper("pluralize", (count, word) => {
   return helpers.pluralize(count, word)
@@ -41,3 +43,4 @@ Template.registerHelper("getProfileImage", image => {
   return helpers.getProfileImage(image)
 })
 
+Template.registerHelper('isModerator', () => isModerator(Meteor.userId()))


### PR DESCRIPTION
Solution: Use a `moderator` flag in the user object to mark users that are maintainers and allow maintainers to delete all problems. Create `isModerator` helper for easy moderator status checking.