### PR TITLE
Problem: Confirm dialogues don't give users the option to cancel action (#154)

### DIFF
--- a/imports/ui/components/documents/show/document-comments.js
+++ b/imports/ui/components/documents/show/document-comments.js
@@ -34,7 +34,8 @@ Template.documentComments.events({
       text: "Are you sure you want to delete this comment?",
       icon: "warning",
       buttons: true,
-      dangerMode: true
+      dangerMode: true,
+      showCancelButton: true
     }).then(confirmed => {
       if (confirmed) {
         let commentId = element.data('comment-id')

--- a/imports/ui/components/documents/show/document-show.js
+++ b/imports/ui/components/documents/show/document-show.js
@@ -88,7 +88,9 @@ Template.documentShow.events({
             swal({
                     text: `Was this problem actually solved by ${(claimer.profile || {}).name}?`,
                     icon: "warning",
+                    buttons: true,
                     dangerMode: true,
+                    showCancelButton: true
                 })
                 .then(confirmed => {
                     if (status === 'closed' && claimer && confirmed) {
@@ -201,7 +203,9 @@ Template.documentShow.events({
         swal({
                 text: "Are you sure you want to delete this problem?",
                 icon: "warning",
+                buttons: true,
                 dangerMode: true,
+                showCancelButton: true
             })
             .then(confirmed => {
                 if (confirmed) {
@@ -230,7 +234,9 @@ Template.documentShow.events({
             swal({
                     text: "Are you sure you want to claim this problem?",
                     icon: "success",
+                    buttons: true,
                     dangerMode: true,
+                    showCancelButton: true
                 })
                 .then(confirmed => {
                     if (confirmed) {
@@ -264,7 +270,9 @@ Template.documentShow.events({
             swal({
                     text: "Are you sure you want to unclaim this problem?",
                     icon: "warning",
+                    buttons: true,
                     dangerMode: true,
+                    showCancelButton: true
                 })
                 .then(confirmed => {
                     if (confirmed) {


### PR DESCRIPTION
Solution: Give users a way to cancel action on all confirm dialogues.