### PR TITLE
Problem: % on stats page is unnecessary and confusing (#175)

### DIFF
--- a/imports/ui/components/stats/userStats.html
+++ b/imports/ui/components/stats/userStats.html
@@ -22,8 +22,8 @@
                   {{#with stats}}
                   <td scope="row">{{nullify loggedProblems.length}}</td>
                   <td>{{nullify claimedProblems.length}}</td>
-                  <td>{{nullify unclaimedProblems.length}} ({{fixed unclaimedPercentage}}%)</td>
-                  <td>{{nullify completedProblems.length}} ({{fixed completedPercentage}}%)</td>
+                  <td>{{nullify unclaimedProblems.length}}</td>
+                  <td>{{nullify completedProblems.length}}</td>
                   {{/with}}
                 </tr>
                 {{/with}} <!-- show the current user first -->
@@ -34,8 +34,8 @@
                   {{#with stats}}
                   <td scope="row">{{nullify loggedProblems.length}}</td>
                   <td>{{nullify claimedProblems.length}}</td>
-                  <td>{{nullify unclaimedProblems.length}} ({{fixed unclaimedPercentage}}%)</td>
-                  <td>{{nullify completedProblems.length}} ({{fixed completedPercentage}}%)</td>
+                  <td>{{nullify unclaimedProblems.length}}</td>
+                  <td>{{nullify completedProblems.length}}</td>
                   {{/with}}
                 </tr>
                 {{/each}}

--- a/imports/ui/components/stats/userStats.js
+++ b/imports/ui/components/stats/userStats.js
@@ -27,12 +27,5 @@ Template.userStats.helpers({
             userId: this._id
         }) || {}
     },
-    unclaimedPercentage: function() {
-        return ((this.claimedProblems || []).length > 0 ? ((this.unclaimedProblems || []).length / this.claimedProblems.length) : 0) * 100
-    },
-    completedPercentage: function() {
-        return ((this.claimedProblems || []).length > 0 ? ((this.completedProblems || []).length / this.claimedProblems.length) : 0) * 100
-    },
-    fixed: val => parseInt(val) !== val ? val.toFixed(2) : val, // fix decimal points only if there are some to prevent 100.00,
     nullify: val => val || 0
 })


### PR DESCRIPTION
Solution: Remove percentages from the stats page.