### PR TITLE
Problem: Delete key not functional after reaching input limit (#186)

### DIFF
--- a/imports/ui/components/documents/shared/problemForm.js
+++ b/imports/ui/components/documents/shared/problemForm.js
@@ -17,9 +17,11 @@ Template.problemForm.events({
         let charsLeftText = inputMaxChars + ' characters left'
     
         $('#' + inputId + '-chars').text(charsLeftText)
-    
+            
+        let specialCodes = [8, 46, 37, 39] // backspace, delete, left, right
+
         if (inputMaxChars <= 0) { 
-          $('#' + inputId).keypress((e) => { return false })
+          $('#' + inputId).keypress((e) => { return !!~specialCodes.indexOf(e.keyCode) })
           return true
         } 
         


### PR DESCRIPTION
Solution: Ignore backspace, delete, left and right arrow keys when limit of characters is reached so that they can still function properly.