### PR TITLE
problem: extra line breaks in markdown #202

### DIFF
--- a/imports/startup/client/config.js
+++ b/imports/startup/client/config.js
@@ -1,4 +1,5 @@
 import { AutoForm } from "meteor/aldeed:autoform"
+import marked from 'marked';
 
 // ***************************************************************
 // Config for client-side only
@@ -7,6 +8,11 @@ import { AutoForm } from "meteor/aldeed:autoform"
 // Extra logging for Autoform. Turn off in production!
 AutoForm.debug()
 
+// Markdown config
+marked.setOptions({
+    gfm: true,
+    breaks: true,
+});
 
 // Theme configurations
 // One-time append required theme's classes to the document body

--- a/imports/ui/components/documents/show/document-comments.html
+++ b/imports/ui/components/documents/show/document-comments.html
@@ -17,7 +17,7 @@
                <a class="btn btn-sm btn-primary edit-comment" role="button">Save</a>
                <a class="btn btn-sm btn-danger cancel-edit" role="button">Cancel</a>
                {{else}}
-               <span class="pre">{{{md comment.comment}}}</span>
+               <span>{{{md comment.comment}}}</span>
                {{/if}}
             </div>
         </div>

--- a/imports/ui/components/documents/show/document-show.html
+++ b/imports/ui/components/documents/show/document-show.html
@@ -18,10 +18,10 @@
           </div>
           <br/>
           <h5 class="card-subtitle">Problem</h5>
-          <p class="card-text font-weight-normal pre">{{{md problem.description}}}</p>
+          <p class="card-text font-weight-normal">{{{md problem.description}}}</p>
           <br/>
           <h5 class="card-subtitle">Solution</h5>
-          <p class="card-text font-weight-normal pre">{{{md problem.solution}}}</p>
+          <p class="card-text font-weight-normal">{{{md problem.solution}}}</p>
           <hr>
           <p class="text-muted float-left" style="margin:0">
             <strong>{{getNameById problem.createdBy}}</strong> created this {{showTimeAgoTimestamp problem.createdAt}} <br/>


### PR DESCRIPTION
solution: the word-wrap attribute that used for render single linebreaks as new lines caused conflict with `marked` library. removed it and configured `marked` to not to ignore single line breaks