### PR TITLE
Problem: Users cannot log 'FYI' type problems (#195)

### DIFF
--- a/imports/api/documents/both/problemMethods.js
+++ b/imports/api/documents/both/problemMethods.js
@@ -55,11 +55,12 @@ export const addProblem = new ValidatedMethod({
             summary: { type: String, max: 70, optional: false},
             description: { type: String, max: 1000, optional: true},
             solution: { type: String, max: 1000, optional: true},
-            isProblemWithEmurgis: { type: Boolean, optional: true }
+            isProblemWithEmurgis: { type: Boolean, optional: true },
+            fyiProblem: { type: Boolean, optional: true }
             //url: {type: String, regEx:SimpleSchema.RegEx.Url, optional: false},
             //image: {label:'Your Image',type: String, optional: true, regEx: /\.(gif|jpg|jpeg|tiff|png)$/
         }).validator(),
-    run({ summary, description, solution, isProblemWithEmurgis }) {
+    run({ summary, description, solution, isProblemWithEmurgis, fyiProblem }) {
     	//Define the body of the ValidatedMethod, e.g. insert some data to a collection
 		if (!Meteor.userId()) {
 			throw new Meteor.Error('Error.', 'You have to be logged in.')
@@ -73,6 +74,7 @@ export const addProblem = new ValidatedMethod({
       'createdBy': Meteor.userId() || "",
       'status':'open',
       'isProblemWithEmurgis': isProblemWithEmurgis,
+      fyiProblem: fyiProblem,
       subscribers: [Meteor.userId()]
     })
 
@@ -229,7 +231,28 @@ export const claimProblem = new ValidatedMethod({
     }
 });
 
-//end
+export const readFYIProblem = new ValidatedMethod({
+    name: 'readFYIProblem',
+    //Define the validation rules which will be applied on both the client and server
+    validate: new SimpleSchema({
+        _id: { type: RegEx, optional: false },
+    }).validator(),
+    run({ _id }) {
+        if (Meteor.userId()) {
+            Problems.update({
+                _id: _id
+            }, {
+                $addToSet: {
+                    read: Meteor.userId()
+                }
+            })
+
+            return _id;
+        } else {
+            throw new Meteor.Error('Error.', 'You have to be logged in.')
+        }
+    }
+})
 
 //allow a user to edit a problem
 export const editProblem = new ValidatedMethod({
@@ -239,9 +262,10 @@ export const editProblem = new ValidatedMethod({
 		'summary': { type: String, max: 70, optional: false},
 		'description': { type: String, max: 1000, optional: true},
         'solution': { type: String, max: 1000, optional: true},
-        'isProblemWithEmurgis': { type: Boolean, optional: true }
+        'isProblemWithEmurgis': { type: Boolean, optional: true },
+        fyiProblem: { type: Boolean, optional: true }
 	}).validator(),
-	run({ id, summary, description, solution, isProblemWithEmurgis }) {
+	run({ id, summary, description, solution, isProblemWithEmurgis, fyiProblem }) {
 		if (!Meteor.userId()) {
 			throw new Meteor.Error('Error.', 'You have to be logged in.')
 		}
@@ -253,7 +277,8 @@ export const editProblem = new ValidatedMethod({
           'summary': summary,
           'description': description || "",
           'solution': solution || "",
-          'isProblemWithEmurgis': isProblemWithEmurgis
+          'isProblemWithEmurgis': isProblemWithEmurgis,
+          fyiProblem: fyiProblem
             }})
     } else {
         throw new Meteor.Error('Error.', 'You cannot edit a problem you did not create')

--- a/imports/ui/components/documents/edit/document-edit.js
+++ b/imports/ui/components/documents/edit/document-edit.js
@@ -52,6 +52,7 @@ Template.documentEdit.events({
 		var data = formData(event.target)
 		
 		data.isProblemWithEmurgis = event.target.isProblemWithEmurgis.checked
+		data.fyiProblem = event.target.fyiProblem.checked
 		data.id = Template.instance().problemId()
 		
     	editProblem.call(data, (err, res) => {

--- a/imports/ui/components/documents/new/document-new.js
+++ b/imports/ui/components/documents/new/document-new.js
@@ -49,6 +49,7 @@ Template.documentNew.events({
     
     var data = formData(event.target)
     data.isProblemWithEmurgis = event.target.isProblemWithEmurgis.checked
+    data.fyiProblem = event.target.fyiProblem.checked
     
     addProblem.call(data, (err, res) => {
       if (!err) { 

--- a/imports/ui/components/documents/shared/problemForm.html
+++ b/imports/ui/components/documents/shared/problemForm.html
@@ -9,6 +9,14 @@
       
       <label class="form-check-label" for="isProblemWithEmurgis">This is a problem with Emurgis itself</label>
     </div>
+    <div class="form-check">
+      {{#if problem.fyiProblem}}
+        <input type="checkbox" class="form-check-input" id="fyiProblem" checked>
+      {{else}}
+        <input type="checkbox" class="form-check-input" id="fyiProblem">
+      {{/if}}
+      <label class="form-check-label" for="fyiProblem">This is an FYI</label>
+    </div>
 
     <div class="input-group" style="padding-top:8px;">
       <textarea class="form-control" id="description" rows="6" value="{{problem.description}}" placeholder="Carefully describe the problem you have observed"></textarea>

--- a/imports/ui/components/documents/show/document-show.html
+++ b/imports/ui/components/documents/show/document-show.html
@@ -35,6 +35,9 @@
           {{#if problem.resolved}}
             Resolved by <strong>{{resolvedByUser problem}}</strong> {{showTimeAgoTimestamp problem.resolvedDateTime}} <br>
           {{/if}}
+          {{#if problem.fyiProblem}}
+            Read and understood by {{#if fyi.firstFive}}{{{fyi.firstFive}}}{{else}}no one{{/if}} {{#if fyi.more.count}}and <span title="{{fyi.more.usernames}}">{{pluralize fyi.more.count "other"}}</span>{{/if}}
+          {{/if}}
           
           </p>
           <div class="float-right">


### PR DESCRIPTION
Solution: On the `new problem` page, add a checkbox which marks the problem as an FYI. If a problem is an FYI, don't allow it to be claimed. Instead, show a button "Got it", which appends the user's name to a list of people who have read and understood the problem.