### PR TITLE
Problem: No dependency indication on sub-problem (#210)

### DIFF
--- a/imports/api/documents/both/.#problemMethods_LOCAL_37007.js
+++ b/imports/api/documents/both/.#problemMethods_LOCAL_37007.js
@@ -1,1 +1,0 @@
-macbook@MACBOOKs-MacBook-Pro.local.37085

--- a/imports/api/documents/both/.#problemMethods_LOCAL_37140.js
+++ b/imports/api/documents/both/.#problemMethods_LOCAL_37140.js
@@ -1,1 +1,0 @@
-macbook@MACBOOKs-MacBook-Pro.local.37217

--- a/imports/api/documents/both/.#problemMethods_REMOTE_37007.js
+++ b/imports/api/documents/both/.#problemMethods_REMOTE_37007.js
@@ -1,1 +1,0 @@
-macbook@MACBOOKs-MacBook-Pro.local.37085

--- a/imports/api/documents/both/.#problemMethods_REMOTE_37140.js
+++ b/imports/api/documents/both/.#problemMethods_REMOTE_37140.js
@@ -1,1 +1,0 @@
-macbook@MACBOOKs-MacBook-Pro.local.37217

--- a/imports/api/documents/both/dependenciesCollection.js
+++ b/imports/api/documents/both/dependenciesCollection.js
@@ -8,5 +8,13 @@ if (Meteor.isServer) {
         } else {
             return Dependencies.find();
         }
-    });
+    })
+
+    Meteor.publish('dependenciesProblem', problemId => Dependencies.find({
+    	$or: [{
+	    	problemId: problemId
+	    }, {
+	    	dependencyId: problemId
+	    }]
+	}))
 }

--- a/imports/ui/components/documents/index/documents-index-item/documents-index-item.html
+++ b/imports/ui/components/documents/index/documents-index-item/documents-index-item.html
@@ -2,7 +2,7 @@
 
   <tr class="documents-index-item {{#if document.isProblemWithEmurgis}}table-info{{/if}}">
     <td scope="row">
-      <div><a href="{{pathFor 'documentShow' documentId=document._id}}">{{document.summary}}</a></div>
+      <div><a href="{{pathFor 'documentShow' documentId=document._id}}">{{document.summary}}</a> {{#if blocking}}<i title='This problem is blocking {{pluralize blocking "other problem"}} from being completed.' style="color: orange;" class="fas fa-exclamation-triangle"></i>{{/if}}</div>
     </td>
     <td>{{showTimeAgoTimestamp document.createdAt}}</td>
     <td>{{{statusText document.status}}}</td>

--- a/imports/ui/components/documents/index/documents-index-item/documents-index-item.js
+++ b/imports/ui/components/documents/index/documents-index-item/documents-index-item.js
@@ -3,15 +3,18 @@ import SimpleSchema from "simpl-schema"
 
 import { notify } from "/imports/modules/notifier"
 import { claimProblem, unclaimProblem, deleteProblem } from "/imports/api/documents/both/problemMethods.js"
+
+import { Dependencies } from '/imports/api/documents/both/dependenciesCollection'
 import { Comments } from "/imports/api/documents/both/commentsCollection.js"
 
 import "./documents-index-item.html"
 import "/imports/ui/components/documents/shared/problem-helpers.js"
 
 Template.documentsIndexItem.onCreated(function() {
-  this.getDocumentId = () => FlowRouter.getParam("documentId")
+  this.getDocumentId = () => this.data.document._id
 
   this.autorun(() => {
+  	this.subscribe('dependenciesProblem', this.getDocumentId())
     this.subscribe("comments", this.getDocumentId())
   })
 })
@@ -24,7 +27,10 @@ Template.documentsIndexItem.helpers({
 	//count number of comments against the problem
     numberOfComments(problemId) {
         return Comments.find({problemId:problemId}).count();
-    }
+    },
+    blocking: () => Dependencies.find({
+    	dependencyId: Template.instance().getDocumentId()
+    }).count()
 })
 
 Template.documentsIndexItem.events({

--- a/imports/ui/components/documents/show/document-show.html
+++ b/imports/ui/components/documents/show/document-show.html
@@ -1,6 +1,13 @@
 <template name="documentShow">
 
   <div class="document-show">
+    {{#if blocking}}
+    <div class="card bg-warning">
+      <div class="card-body">
+        This problem is blocking {{pluralize blocking "other problem"}} from being completed.
+      </div>
+    </div>
+    {{/if}}
     <div class="card {{#if problem.isProblemWithEmurgis}}border-info{{/if}}">
       <div class="card-body">
         {{#if Template.subscriptionsReady}}

--- a/imports/ui/components/documents/show/document-show.js
+++ b/imports/ui/components/documents/show/document-show.js
@@ -26,7 +26,7 @@ Template.documentShow.onCreated(function() {
     this.subscribe('users')
     this.subscribe("problems", this.getDocumentId())
     this.subscribe("comments", this.getDocumentId())
-    this.subscribe("dependencies", this.getDocumentId())
+    this.subscribe("dependenciesProblem", this.getDocumentId())
   })
 
   this.commentInvalidMessage = new ReactiveVar("")
@@ -37,6 +37,9 @@ Template.documentShow.onRendered(function() {})
 Template.documentShow.onDestroyed(function() {})
 
 Template.documentShow.helpers({
+    blocking: () => Dependencies.find({
+        dependencyId: Template.instance().getDocumentId()
+    }).count(),
     rejected: () => {
         let problem = Problems.findOne({
             _id: Template.instance().getDocumentId()


### PR DESCRIPTION
Solution: Add a warning bar to sub-problem's detail page saying 'This problem is blocking x other problem(s) from being completed'. Put a warning icon in-line next to the problem summary on the home route.