### PR TITLE
Problem: Status of dependencies not shown on parent problem detail page (#212)

### DIFF
--- a/imports/ui/components/documents/shared/problem-helpers.js
+++ b/imports/ui/components/documents/shared/problem-helpers.js
@@ -27,7 +27,7 @@ Template.registerHelper('statusText', status => {
     if (status && status === 'open') {
         return '<span class="badge badge-success">Open</span>'
     } else if (status && status === 'closed') {
-        return '<span class="badge badge-danger">This is fixed/solved</span>'
+        return '<span class="badge badge-danger">Fixed/solved</span>'
     } else if (status && status === 'in progress') {
         return '<span class="badge badge-secondary">In progress</span>'
     } else if (status && status === 'ready for review') {
@@ -42,3 +42,7 @@ Template.registerHelper('statusText', status => {
 Template.registerHelper('getSummaryById', id => {
     return  Problems.findOne({_id: id}).summary;
 })
+
+Template.registerHelper('getStatusById', id => (Problems.findOne({
+    _id: id
+}) || {}).status || '')

--- a/imports/ui/components/documents/show/document-show.html
+++ b/imports/ui/components/documents/show/document-show.html
@@ -30,7 +30,7 @@
           {{#if dependencies.count}} <h5>Dependencies</h5> {{/if}}
           {{#each dependencies}}
             <div>
-              <a href="{{pathFor 'documentShow' documentId=dependencyId}}">{{getSummaryById dependencyId}}</a>{{#if isProblemOwner problem.createdBy}}<a href="#" class="remove-dep"><sup>X</sup></a>{{/if}}
+              <a href="{{pathFor 'documentShow' documentId=dependencyId}}">{{getSummaryById dependencyId}}</a>{{#if isProblemOwner problem.createdBy}} {{{statusText (getStatusById dependencyId)}}} <a class="btn btn-sm btn-danger remove-dep" style="height: 15px;font-size: 10px;padding: 0px 5px 0px 5px;" href="#" role="button">X</a>{{/if}}
             </div>
           {{/each}}
           <hr>


### PR DESCRIPTION
Solution: Add a badge which displays the status of a dependency problem on parent problem's details page. Change delete button UI to fit the badge.