### PR TITLE
Problem: Users aren't guided enough when adding problems (#221)

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -38,3 +38,4 @@ msavin:mongol
 accounts-google
 service-configuration
 google-config-ui
+reactive-dict

--- a/imports/api/user/both/userMethods.js
+++ b/imports/api/user/both/userMethods.js
@@ -1,3 +1,8 @@
+import { Meteor } from 'meteor/meteor'
+
+import SimpleSchema from 'simpl-schema'
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+
 export const isModerator = userId => {
 	let user = Meteor.users.findOne({
         _id: userId
@@ -5,3 +10,61 @@ export const isModerator = userId => {
 
     return user && user.moderator
 }
+
+export const hideHelpModal = new ValidatedMethod({
+    name: 'hideHelpModal',
+    validate: new SimpleSchema({
+    	helpModalId: {
+    		type: String,
+    		optional: false
+    	}
+    }).validator({
+    	clean: true
+    }),
+    run({ helpModalId }) {
+        if (!Meteor.userId()) {
+            throw new Meteor.Error('Error.', 'You have to be logged in.')
+        }
+        
+        return Meteor.users.update({
+        	_id: Meteor.userId()
+        }, {
+        	$addToSet: {
+        		hidden: helpModalId
+        	}
+        })
+    }
+})
+
+export const resetHiddenModals = new ValidatedMethod({
+    name: 'resetHiddenModals',
+    validate: new SimpleSchema({
+    	userId: {
+    		type: String,
+    		optional: false
+    	}
+    }).validator({
+    	clean: true
+    }),
+    run({ userId }) {
+        if (!Meteor.userId()) {
+            throw new Meteor.Error('Error.', 'You have to be logged in.')
+        }
+
+        let curUser = Meteor.users.findOne({
+        	_id: Meteor.userId()
+        })
+
+        if (!curUser || !curUser.moderator) {
+        	throw new Meteor.Error('Error.', 'You have to be a moderator in order to do this.')
+        }
+        
+        return Meteor.users.update({
+        	_id: userId
+        }, {
+        	$set: {
+        		hidden: []
+        	}
+        })
+    }
+})

--- a/imports/api/user/server/publications.js
+++ b/imports/api/user/server/publications.js
@@ -21,6 +21,7 @@ Meteor.publish(null, () => Meteor.users.find({
 	fields: {
 		'profile.name': 1,
 		_id: 1,
-		moderator: 1
+		moderator: 1,
+		hidden: 1
 	}
 }))

--- a/imports/startup/client/router/group-config.js
+++ b/imports/startup/client/router/group-config.js
@@ -2,3 +2,8 @@ import { FlowRouter } from "meteor/kadira:flow-router"
 import { Meteor } from "meteor/meteor"
 
 export const appRoutes = FlowRouter.group({ })
+
+export const modRoutes = FlowRouter.group({
+	prefix: '/moderator',
+  	name: 'moderator'
+})

--- a/imports/startup/client/router/mod-routes.js
+++ b/imports/startup/client/router/mod-routes.js
@@ -1,0 +1,17 @@
+import { FlowRouter } from 'meteor/kadira:flow-router'
+import { BlazeLayout } from 'meteor/kadira:blaze-layout'
+import { modRoutes } from './group-config'
+
+import '/imports/ui/components/moderator/users/userList'
+
+modRoutes.route('/users', {
+    action: () => {
+        BlazeLayout.render('layout', {
+          main: 'userList',
+          footer: 'footer',
+          header: 'header',
+          sidebar: 'sidebar'
+        })
+    },
+    name: 'userList'
+})

--- a/imports/startup/client/router/router.js
+++ b/imports/startup/client/router/router.js
@@ -10,3 +10,4 @@ import "./filter-config.js"
 import './stats-routes.js'
 import './notifications-routes.js'
 import "./document-routes.js"
+import './mod-routes'

--- a/imports/ui/components/documents/shared/problemForm.html
+++ b/imports/ui/components/documents/shared/problemForm.html
@@ -22,13 +22,13 @@
       <textarea class="form-control" id="description" rows="6" value="{{problem.description}}" placeholder="Carefully describe the problem you have observed"></textarea>
       <div id="descriptionError" class="invalid-feedback"></div>
     </div>
-    <small><i id="description-chars" class="text-muted"></i></small>
+    <small><a class="far fa-question-circle" data-id="description" style="display: none"></a> <i id="description-chars" class="text-muted"></i></small>
 
     <div class="input-group" style="padding-top:8px;">
       <textarea class="form-control" id="solution" rows="6" value="{{problem.solution}}" placeholder="This is optional. If you have some ideas of what the simplest possible solution to this problem is, you can explain it here."></textarea>
       <div id="solutionError" class="invalid-feedback"></div>
     </div>
-    <small><i id="solution-chars" class="text-muted"></i></small>
+    <small><a class="far fa-question-circle" data-id="solution" style="display: none"></a> <i id="solution-chars" class="text-muted"></i></small>
 
     <div class="input-group" style="padding-top:8px;">
       <div class="input-group-prepend">
@@ -38,7 +38,7 @@
       <input type="text" class="form-control" id="summary" value="{{problem.summary}}" placeholder="summarize the problem in 63 characters or less">
       <div id="summaryError" class="invalid-feedback"></div>
     </div>
-    <small><i id="summary-chars" class="text-muted"></i></small>
+    <small><a class="far fa-question-circle" data-id="summary" style="display: none"></a> <i id="summary-chars" class="text-muted"></i></small>
     <div class="input-group" style="padding-top:8px;">
       <div class="input-group-prepend">
         <div class="input-group-text">Estimate <i> (Minutes)</i>:</div>

--- a/imports/ui/components/moderator/users/userList.html
+++ b/imports/ui/components/moderator/users/userList.html
@@ -1,0 +1,35 @@
+<template name="userList">
+  <div class="user-index">
+    <div class="card">
+      <div class="card-body">
+        {{#if isModerator}}
+        <h1>Users</h1>
+
+        {{#if Template.subscriptionsReady}}
+            <table class="table table-hover mt-3">
+              <thead>
+                <tr>
+                  <th>Username</th>
+                  <th>Reset hidden modals</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{#each users}}
+                <tr class="user-item">
+                  <td>{{profile.name}}</td>
+                  <td><a href="#" class="btn btn-sm btn-primary reset">Reset</a></td>
+                </tr>
+                {{/each}}
+              </tbody>
+            </table>
+        {{else}}
+          {{> loader}}
+        {{/if}}
+        {{else}}
+        <h1>This page is for moderators only.</h1>
+        {{/if}}
+      </div>
+    </div>
+  </div>
+
+</template>

--- a/imports/ui/components/moderator/users/userList.js
+++ b/imports/ui/components/moderator/users/userList.js
@@ -1,0 +1,37 @@
+import { Template } from 'meteor/templating'
+import { FlowRouter } from 'meteor/kadira:flow-router'
+
+import './userList.html'
+
+import { resetHiddenModals } from '/imports/api/user/both/userMethods'
+import { notify } from '/imports/modules/notifier'
+
+Template.userList.onCreated(function() {
+    this.autorun(() => {
+        this.subscribe('users')
+    })
+})
+
+Template.userList.helpers({
+    users: () => Meteor.users.find({}, {
+        sort: {
+            'profile.name': 1
+        }
+    })
+})
+
+Template.userList.events({
+    'click .reset': function(event, templateInstance) {
+        event.preventDefault()
+
+        resetHiddenModals.call({
+            userId: this._id
+        }, (err, data) => {
+            if (err) {
+                notify(err.reason || err.message, 'error')
+            } else {
+                notify('Successfully reset.', 'success')
+            }
+        })
+    }
+})

--- a/imports/ui/shared/sidebar/sidebar.html
+++ b/imports/ui/shared/sidebar/sidebar.html
@@ -25,6 +25,13 @@
                 <li class="nav-item"><a href="/rejected" class="nav-link">
                     <i class="nav-icon icon-docs"></i> My rejected problems</a>
                 </li>
+
+                <!-- mdoerator pages -->
+                {{#if isModerator}}
+                <li class="nav-item"><a href="/moderator/users" class="nav-link">
+                    <i class="nav-icon icon-people"></i> User management</a>
+                </li>
+                {{/if}}
             </ul>
         </nav>
         <button class="sidebar-minimizer" type="button"></button>


### PR DESCRIPTION
Solution: Add a modal for each field of the new problem page which shows when users start typing and let users hide the modal permanently after reading it if they wish. Put a small question mark icon below each field so users can access the modal again if they need to. Add a new page (`/moderator/users`) where moderators can manage users and reset their hidden modal flags, so they can force modals to show to users who often make mistakes.