### PR TITLE
Problem: Wrong icon in claim confirmation popup (#338)

### DIFF
--- a/imports/ui/components/documents/show/document-show.js
+++ b/imports/ui/components/documents/show/document-show.js
@@ -515,7 +515,7 @@ Template.documentShow.events({
          let problemId = Template.instance().getDocumentId()
          swal({
                  text: "Are you sure you want to claim this problem?",
-                 icon: "success",
+                 icon: "warning",
                  buttons: true,
                  dangerMode: true,
                  showCancelButton: true


### PR DESCRIPTION
Solution: Change the icon in claim confirmation popup from 'success' to 'warning'.