### PR TITLE
Problem: Users cannot show their approval for new problems (#365)

### DIFF
--- a/imports/api/documents/both/problemMethods.test.js
+++ b/imports/api/documents/both/problemMethods.test.js
@@ -337,6 +337,36 @@ describe('problem methods', () => {
       })
     })
 
+    it ('users can +1 a problem', () => {
+      let problem = Problems.findOne({})
+      assert.ok(problem)
+
+      return callWithPromise('problemApproval', {
+        _id: problem._id
+      }).then(data => {
+        let p = Problems.findOne({
+          _id: problem._id
+        })
+
+        assert.notEqual(p.approvals.indexOf(Meteor.userId()), -1)
+      })
+    })
+
+    it ('users can -1 a problem', () => {
+      let problem = Problems.findOne({})
+      assert.ok(problem)
+
+      return callWithPromise('problemApproval', {
+        _id: problem._id
+      }).then(data => {
+        let p = Problems.findOne({
+          _id: problem._id
+        })
+
+        assert.equal(p.approvals.indexOf(Meteor.userId()), -1)
+      })
+    })
+
     it ('users can unsubscribe from a problem', () => {
       let problem = Problems.findOne({})
       assert.ok(problem)

--- a/imports/ui/components/documents/show/document-show.html
+++ b/imports/ui/components/documents/show/document-show.html
@@ -69,6 +69,9 @@
           {{#if problem.fyiProblem}}
             Read and understood by {{#if fyi.firstFive}}{{{fyi.firstFive}}}{{else}}no one{{/if}} {{#if fyi.more.count}}and <span title="{{fyi.more.usernames}}">{{pluralize fyi.more.count "other"}}</span>{{/if}}
           {{/if}}
+          {{#if approval.firstFive}}
+            Has approval by {{{approval.firstFive}}} {{#if approval.more.count}}and <span title="{{approval.more.usernames}}">{{pluralize approval.more.count "other"}}</span>{{/if}}
+          {{/if}}
 
           </p>
           {{#unless rejected}}
@@ -150,6 +153,9 @@
             </p>
             {{#if SubsCacheReady}}
             <span class="problem-action-buttons float-right">
+              {{#unless isOwner problem}}
+              <a class="btn btn-sm btn-primary problemApproval" href="#" role="button">{{#if alreadyApproved}}-{{else}}+{{/if}}1</a>
+              {{/unless}}
               {{{claimButton problem}}}
               {{{watchButton problem}}}
               {{#if problem.claimed}}

--- a/imports/ui/components/documents/show/tests/document-show.ui-test.js
+++ b/imports/ui/components/documents/show/tests/document-show.ui-test.js
@@ -64,6 +64,27 @@ describe('Problem page', function () {
         assert(browser.execute(() => $('#comment-images').length).value === c - 1, true)
     })
 
+    it('user can +1 a problem', () => {
+        if (browser.isExisting('.problemApproval') && browser.isVisible('.problemApproval')) {
+            let old = browser.execute(() => $('.problemApproval').text()).value
+
+            browser.click('.problemApproval')
+
+            browser.pause(3000)
+
+            if (browser.isExisting('.swal-button--confirm') && browser.isVisible('.swal-button--confirm')) {
+                browser.click('.swal-button--confirm')
+                browser.pause(2000)
+            }
+
+            if (old === '+1') {
+                assert(browser.execute(() => $('.problemApproval').text()).value === '-1', true)
+            } else {
+                assert(browser.execute(() => $('.problemApproval').text()).value === '+1', true)
+            }
+        }
+    })
+
     it('user can claim a problem', () => {
         let isClaimed = browser.execute(() => $('.unclaimProblem').length === 1).value
 


### PR DESCRIPTION
Solution: Allow other users to react with a "+1" showing that they agree this is a problem that should be solved. Add a modal for the first time they click "+1" explaining that. Allow moderators to reset this modal as they reset all other modals on the side.