### PR TITLE
Problem: Moderators cannot force-unclaim users from issues (#362)

### DIFF
--- a/imports/ui/components/documents/show/document-show.html
+++ b/imports/ui/components/documents/show/document-show.html
@@ -79,6 +79,7 @@
             {{else}}
             {{#if isModerator}}
             <button data-toggle="modal" data-target="#rejectModal" class="btn btn-sm btn-danger" role="button">Reject Problem</button>
+            {{#if problem.claimed}}<button class="btn btn-sm btn-danger forceUnclaim" role="button">Force unclaim</button>{{/if}}
             {{/if}}
             {{/if}}
           </div>

--- a/imports/ui/components/documents/show/document-show.js
+++ b/imports/ui/components/documents/show/document-show.js
@@ -4,7 +4,7 @@ import { notify } from "/imports/modules/notifier"
 import swal from 'sweetalert'
 
 import { Problems } from "/imports/api/documents/both/problemCollection.js"
-import { markAsUnSolved, markAsResolved, updateStatus, claimProblem, unclaimProblem, deleteProblem, watchProblem, unwatchProblem, readFYIProblem, removeClaimer, removeProblemImage } from "/imports/api/documents/both/problemMethods.js"
+import { markAsUnSolved, markAsResolved, updateStatus, claimProblem, unclaimProblem, deleteProblem, watchProblem, unwatchProblem, readFYIProblem, removeClaimer, removeProblemImage, forceUnclaim } from "/imports/api/documents/both/problemMethods.js"
 import { Dependencies } from "/imports/api/documents/both/dependenciesCollection.js"
 import { deleteDependency, addDependency } from '/imports/api/documents/both/dependenciesMethods'
 import { Comments } from "/imports/api/documents/both/commentsCollection.js"
@@ -316,6 +316,27 @@ Template.documentShow.events({
       }
     })
   },
+    'click .forceUnclaim': function (event, templateInstance) {
+        event.preventDefault()
+
+        swal({
+            text: `Are you sure you want to forcefully remove the current claimer?`,
+            icon: 'warning',
+            buttons: true,
+            dangerMode: true,
+            showCancelButton: true
+        }).then(confirmed => {
+            if (confirmed) {
+                forceUnclaim.call({
+                    _id: templateInstance.getDocumentId()
+                }, (err, data) => {
+                    if (err) {
+                        notify(err.reason || err.message, 'error')
+                    }
+                })
+            }
+        })
+    },
   'click .remove-dep': function (event, templateInstance) {
     event.preventDefault()
 


### PR DESCRIPTION
Solution: Allow moderators to forcefully remove the current claimer on a given problem.