### PR TITLE
Problem: Header logo overlaying in tablet view #395

### DIFF
--- a/imports/ui/shared/header/header.scss
+++ b/imports/ui/shared/header/header.scss
@@ -37,4 +37,6 @@ header.app-header .navbar-nav { padding-left: 6px; }
 @media (max-width: 991px) {
   header.app-header .navbar-nav { margin: 0px 5px; padding: 0px; }
   header.app-header .nav-item { min-width: 40px; }
+
+  header.app-header .navbar-brand { left: 3%; margin-left: 5px; }
 }


### PR DESCRIPTION
Solution: set logo in left side as it is in desktop